### PR TITLE
Use install-action to install cargo-audit

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -39,5 +39,6 @@ jobs:
           while read -rd' '; do
             additional_targets+=(--target "${REPLY}")
           done <<<"${{ inputs.additional-targets }} "
+          set -x
           cargo clippy --all-features --all-targets "${additional_targets[@]}"
         if: inputs.additional-targets != ''

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
       # rustsec/audit-check used to do this automatically
       - name: Generate Cargo.lock
         run: cargo generate-lockfile


### PR DESCRIPTION
It's currently very slow because it's installed from source. https://github.com/smol-rs/async-fs/actions/runs/16389907343/job/46314498798?pr=47#step:5:15